### PR TITLE
:ghost: Add multi-arch build workflow.

### DIFF
--- a/.github/workflows/march-image-build-push.yaml
+++ b/.github/workflows/march-image-build-push.yaml
@@ -1,0 +1,30 @@
+name: 'Build and Push Multi-Arch Image'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'release-*'
+    tags:
+      - 'v*'
+
+concurrency:
+  group: march-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  push-quay:
+    uses: konveyor/release-tools/.github/workflows/build-push-images.yaml@main
+    with:
+      registry: "quay.io/konveyor"
+      image_name: "tackle2-addon-platform"
+      containerfile: "./Dockerfile"
+      architectures: '[ "amd64", "arm64" ]'
+      extra-args: |
+        --build-arg
+        VERSION=${{ github.tag}}-${{ github.ref }}
+    secrets:
+      registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+      registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new automated workflow to build and push multi-architecture container images to the registry, supporting both manual and branch-based triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->