### PR TITLE
:sparkles: Inject generator static values and params

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/konveyor/tackle2-hub/api"
+	"github.com/onsi/gomega"
+)
+
+func TestManifestMerge(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	m := api.Map{
+		"a": Map{
+			"b": 2,
+		},
+		"c": 25,
+	}
+	d := api.Map{
+		"a.b":   100,
+		"a.n.x": 200,
+		"a.n.y": 200,
+		"c":     300,
+	}
+
+	gen := Generate{}
+	gen.inject(m, d)
+
+	expected := api.Map{
+		"a": Map{
+			"b": 100,
+			"n": Map{
+				"x": 200,
+				"y": 200,
+			},
+		},
+		"c": 300,
+	}
+	g.Expect(expected).To(gomega.BeEquivalentTo(m))
+}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -56,7 +56,7 @@ func (a *Generate) Run(d *Data) (err error) {
 	assetDir := path.Join(
 		AssetDir,
 		a.application.Assets.Path)
-	generators, err := a.generators(d.AssetGen.Profiles)
+	generators, err := a.generators(d.Profiles)
 	if err != nil {
 		return
 	}
@@ -74,7 +74,7 @@ func (a *Generate) Run(d *Data) (err error) {
 		var names []string
 		names, err = a.generate(
 			gen,
-			d.AssetGen.Params,
+			d.Params,
 			templateDir,
 			assetDir)
 		if err != nil {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -24,7 +24,7 @@ func (a *Import) Run(d *Data) (err error) {
 		return
 	}
 	created := make([]api.Application, 0)
-	applications, err := provider.Find(d.Filter)
+	applications, err := provider.Find(d.Import.Filter)
 	if err != nil {
 		return
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -24,7 +24,7 @@ func (a *Import) Run(d *Data) (err error) {
 		return
 	}
 	created := make([]api.Application, 0)
-	applications, err := provider.Find(d.Import.Filter)
+	applications, err := provider.Find(d.Filter)
 	if err != nil {
 		return
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,17 +28,13 @@ type Data struct {
 	// Action (fetch|import|generate)
 	Action string `json:"action"`
 	// Import
-	Import struct {
-		// Filter applications.
-		Filter api.Map `json:"filter"`
-	}
-	// AssetGen (asset)
-	AssetGen struct {
-		// Profiles
-		Profiles Profiles `json:"profiles"`
-		// Params generator params
-		Params api.Map `json:"parameters"`
-	}
+	// Filter applications.
+	Filter api.Map `json:"filter"`
+	// Asset Generation
+	// Profiles
+	Profiles Profiles `json:"profiles"`
+	// Params generator params
+	Params api.Map `json:"params"`
 }
 
 // main

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,10 +27,18 @@ func init() {
 type Data struct {
 	// Action (fetch|import|generate)
 	Action string `json:"action"`
-	// Filter applications.
-	Filter api.Map `json:"filter"`
-	// Profiles used for asset generation.
-	Profiles Profiles `json:"profiles"`
+	// Import
+	Import struct {
+		// Filter applications.
+		Filter api.Map `json:"filter"`
+	}
+	// AssetGen (asset)
+	AssetGen struct {
+		// Profiles
+		Profiles Profiles `json:"profiles"`
+		// Params generator params
+		Params api.Map `json:"parameters"`
+	}
 }
 
 // main


### PR DESCRIPTION
Adds:
- inject Generator.Values (static values) into the manifest.
- inject user defined params into the manifest.

The difference between _values_ and _params_ is: params are defined by the user in the assetgen flow and passed though the task.Data.  The values are static and defined on each generator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for injecting additional parameters into manifest generation, allowing for more dynamic and flexible template customization.

* **Bug Fixes**
  * Improved merging of nested values using dot notation for keys, ensuring correct overriding and extension of manifest data.

* **Tests**
  * Introduced a new test to verify correct merging behavior of nested manifest values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->