### PR TITLE
:sparkles: Support manifest in source repository.

### DIFF
--- a/cmd/cloudfoundry/error.go
+++ b/cmd/cloudfoundry/error.go
@@ -1,0 +1,25 @@
+package cloudfoundry
+
+import (
+	"errors"
+
+	liberr "github.com/jortel/go-utils/error"
+)
+
+var (
+	Wrap = liberr.Wrap
+)
+
+type CoordinatesError struct {
+}
+
+func (m *CoordinatesError) Error() (s string) {
+	s = "Application coordinates not defined."
+	return
+}
+
+func (e *CoordinatesError) Is(err error) (matched bool) {
+	var inst *CoordinatesError
+	matched = errors.As(err, &inst)
+	return
+}

--- a/cmd/cloudfoundry/provider.go
+++ b/cmd/cloudfoundry/provider.go
@@ -9,7 +9,6 @@ import (
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/api/jsd"
 	"github.com/konveyor/tackle2-hub/migration/json"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -30,7 +29,7 @@ func (p *Provider) Use(identity *api.Identity) {
 // Fetch the manifest for the application.
 func (p *Provider) Fetch(application *api.Application) (m *api.Manifest, err error) {
 	if application.Coordinates == nil {
-		err = errors.Errorf("Coordinates required.")
+		err = &CoordinatesError{}
 		return
 	}
 	coordinates := Coordinates{}
@@ -48,6 +47,7 @@ func (p *Provider) Fetch(application *api.Application) (m *api.Manifest, err err
 	}
 	manifest, err := client.Discover(ref)
 	if err != nil {
+		err = Wrap(err)
 		return
 	}
 	m = &api.Manifest{}
@@ -113,6 +113,7 @@ func (p *Provider) client(spaces ...string) (client *cfp.CloudFoundryProvider, e
 	}
 	cfConfig, err := cf.New(p.URL, options...)
 	if err != nil {
+		err = Wrap(err)
 		return
 	}
 	pConfig := &cfp.Config{
@@ -121,6 +122,7 @@ func (p *Provider) client(spaces ...string) (client *cfp.CloudFoundryProvider, e
 	}
 	client, err = cfp.New(pConfig, &addon.Log, true)
 	if err != nil {
+		err = Wrap(err)
 		return
 	}
 	return

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+
+	liberr "github.com/jortel/go-utils/error"
+)
+
+var (
+	Wrap = liberr.Wrap
+)
+
+type ManifestError struct {
+}
+
+func (m *ManifestError) Error() (s string) {
+	s = "No manifest associated with the application or found in the source repository."
+	return
+}
+
+func (e *ManifestError) Is(err error) (matched bool) {
+	var inst *ManifestError
+	matched = errors.As(err, &inst)
+	return
+}
+
+type SourceRepoError struct {
+}
+
+func (m *SourceRepoError) Error() (s string) {
+	s = "Application source repository not defined."
+	return
+}
+
+func (e *SourceRepoError) Is(err error) (matched bool) {
+	var inst *AssetRepoError
+	matched = errors.As(err, &inst)
+	return
+}
+
+type AssetRepoError struct {
+}
+
+func (m *AssetRepoError) Error() (s string) {
+	s = "Application asset repository not defined."
+	return
+}
+
+func (e *AssetRepoError) Is(err error) (matched bool) {
+	var inst *AssetRepoError
+	matched = errors.As(err, &inst)
+	return
+}
+
+type PlatformError struct {
+}
+
+func (m *PlatformError) Error() (s string) {
+	s = "Application not associated with platform."
+	return
+}
+
+func (e *PlatformError) Is(err error) (matched bool) {
+	var inst *PlatformError
+	matched = errors.As(err, &inst)
+	return
+}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path"
 	"strconv"
@@ -8,9 +9,12 @@ import (
 
 	"github.com/konveyor/tackle2-addon/repository"
 	"github.com/konveyor/tackle2-hub/api"
+	"github.com/konveyor/tackle2-hub/binding"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
 type Files = map[string]string
+type Map = map[string]any
 
 // Generate assets action.
 type Generate struct {
@@ -35,7 +39,7 @@ func (a *Generate) Run(d *Data) (err error) {
 		a.application.ID,
 		a.application.Name)
 	if a.application.Assets == nil {
-		addon.Failed("[Gen] asset repository not defined.")
+		err = Wrap(&AssetRepoError{})
 		return
 	}
 	identity, err := a.selectIdentity("asset")
@@ -135,6 +139,7 @@ func (a *Generate) generate(
 func (a *Generate) writeAsset(assetPath, content string) (err error) {
 	f, err := os.Create(assetPath)
 	if err != nil {
+		err = Wrap(err)
 		return
 	}
 	defer func() {
@@ -142,6 +147,7 @@ func (a *Generate) writeAsset(assetPath, content string) (err error) {
 	}()
 	_, err = f.Write([]byte(content))
 	if err != nil {
+		err = Wrap(err)
 		return
 	}
 	addon.Activity(
@@ -152,17 +158,11 @@ func (a *Generate) writeAsset(assetPath, content string) (err error) {
 
 // values returns the `values` file passed to the generator.
 func (a *Generate) values(injected ...api.Map) (values api.Map, err error) {
-	tags := []api.Tag{}
-	for _, ref := range a.application.Tags {
-		var tag *api.Tag
-		tag, err = addon.Tag.Get(ref.ID)
-		if err != nil {
-			return
-		}
-		tags = append(tags, *tag)
+	tags, err := a.tags()
+	if err != nil {
+		return
 	}
-	mapi := addon.Application.Manifest(a.application.ID)
-	manifest, err := mapi.Get()
+	manifest, err := a.manifest()
 	if err != nil {
 		return
 	}
@@ -176,6 +176,45 @@ func (a *Generate) values(injected ...api.Map) (values api.Map, err error) {
 	return
 }
 
+// fetchRepository gets source repository.
+func (a *Generate) fetchRepository() (sourceDir string, err error) {
+	if a.application.Repository == nil {
+		err = Wrap(&SourceRepoError{})
+		return
+	}
+	var options []any
+	idapi := addon.Application.Identity(a.application.ID)
+	identity, found, err := idapi.Find("source")
+	if err != nil {
+		return
+	}
+	if found {
+		options = append(options, identity)
+	}
+	sourceDir = path.Join(
+		SourceDir,
+		strings.Split(
+			path.Base(
+				a.application.Repository.URL),
+			".")[0])
+	var rp repository.SCM
+	rp, err = repository.New(
+		sourceDir,
+		a.application.Repository,
+		options...)
+	if err != nil {
+		return
+	}
+	err = rp.Fetch()
+	if err != nil {
+		return
+	}
+	sourceDir = path.Join(
+		sourceDir,
+		a.application.Repository.Path)
+	return
+}
+
 // fetchTemplates clones the repository associated with the generator.
 func (a *Generate) fetchTemplates(gen *api.Generator) (templateDir string, err error) {
 	genId := strconv.Itoa(int(gen.ID))
@@ -184,6 +223,7 @@ func (a *Generate) fetchTemplates(gen *api.Generator) (templateDir string, err e
 		genId)
 	err = os.MkdirAll(templateDir, 0755)
 	if err != nil {
+		err = Wrap(err)
 		return
 	}
 	template, err := repository.New(
@@ -266,6 +306,75 @@ func (a *Generate) inject(manifest, d api.Map) {
 	}
 }
 
+// tags returns an array of tags.
+// format: category=tag.
+func (a *Generate) tags() (tags []string, err error) {
+	catList, err := addon.TagCategory.List()
+	if err != nil {
+		return
+	}
+	catMap := make(map[uint]string)
+	for _, cat := range catList {
+		catMap[cat.ID] = cat.Name
+	}
+	for _, ref := range a.application.Tags {
+		var tag *api.Tag
+		tag, err = addon.Tag.Get(ref.ID)
+		if err != nil {
+			return
+		}
+		tags = append(
+			tags,
+			strings.Join(
+				[]string{
+					catMap[tag.Category.ID],
+					tag.Name},
+				"="))
+	}
+	return
+}
+
+// manifest returns the application manifest.
+// Fallback: A file named: manifest.yaml in the source repository.
+func (a *Generate) manifest() (manifest *api.Manifest, err error) {
+	mapi := addon.Application.Manifest(a.application.ID)
+	manifest, err = mapi.Get()
+	if err != nil {
+		if !errors.Is(err, &binding.NotFound{}) {
+			return
+		}
+	} else {
+		return
+	}
+	if a.application.Repository == nil {
+		err = &ManifestError{}
+		return
+	}
+	sourceDir, err := a.fetchRepository()
+	if err != nil {
+		return
+	}
+	file := path.Join(sourceDir, "manifest.yaml")
+	f, err := os.Open(file)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	manifest = &api.Manifest{}
+	decoder := yaml.NewDecoder(f)
+	err = decoder.Decode(&manifest.Content)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = &ManifestError{}
+		} else {
+			err = Wrap(err)
+		}
+	}
+	return
+}
+
 // Profiles selected profiles.
 type Profiles []api.Ref
 
@@ -283,5 +392,3 @@ func (f Profiles) match(p *api.TargetProfile) (matched bool) {
 	}
 	return
 }
-
-type Map = map[string]any

--- a/cmd/helm/generator.go
+++ b/cmd/helm/generator.go
@@ -1,8 +1,13 @@
 package helm
 
 import (
+	liberr "github.com/jortel/go-utils/error"
 	hp "github.com/konveyor/asset-generation/pkg/providers/generators/helm"
 	"github.com/konveyor/tackle2-hub/api"
+)
+
+var (
+	Wrap = liberr.Wrap
 )
 
 type Files = map[string]string
@@ -22,6 +27,7 @@ func (g *Engine) Generate(templateDir string, values api.Map) (files Files, err 
 	provider := hp.New(config)
 	files, err = provider.Generate()
 	if err != nil {
+		err = Wrap(err)
 		return
 	}
 	return

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	addon       = hub.Addon
+	SourceDir   = ""
 	TemplateDir = ""
 	AssetDir    = ""
 	Dir         = ""
@@ -19,6 +20,7 @@ var (
 
 func init() {
 	Dir, _ = os.Getwd()
+	SourceDir = path.Join(Dir, "source")
 	TemplateDir = path.Join(Dir, "templates")
 	AssetDir = path.Join(Dir, "assets")
 }
@@ -40,6 +42,7 @@ type Data struct {
 // main
 func main() {
 	addon.Run(func() (err error) {
+		addon.Activity("SourceDir: %s", SourceDir)
 		addon.Activity("TemplateDir: %s", TemplateDir)
 		addon.Activity("AssetDir: %s", AssetDir)
 		//
@@ -51,9 +54,10 @@ func main() {
 		}
 		//
 		// Create directories.
-		for _, dir := range []string{TemplateDir, AssetDir} {
+		for _, dir := range []string{SourceDir, TemplateDir, AssetDir} {
 			err = nas.MkDir(dir, 0755)
 			if err != nil {
+				err = Wrap(err)
 				return
 			}
 		}


### PR DESCRIPTION
Support manifest in source repository as file named: `manifest.yaml`.  Apparently this is a convention.

Include tags in the `values.yaml` as:
category=tag.

Improved error handling & reporting.