### PR TITLE
:bug: Support asset repository without path.

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -127,6 +127,9 @@ func (a *Generate) purge(assetDir string) (err error) {
 				return
 			}
 			if strings.HasPrefix(path.Base(entPath), ".") {
+				if ent.IsDir() {
+					err = fp.SkipDir
+				}
 				return
 			}
 			if ent.IsDir() {
@@ -231,6 +234,12 @@ func (a *Generate) writeTemplates(templateDir, assetDir string) (err error) {
 		func(entPath string, ent os.FileInfo, nErr error) (err error) {
 			if nErr != nil {
 				err = wrap(nErr)
+				return
+			}
+			if strings.HasPrefix(path.Base(entPath), ".") {
+				if ent.IsDir() {
+					err = fp.SkipDir
+				}
 				return
 			}
 			assetPath, _ := fp.Rel(templateDir, entPath)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -66,6 +66,10 @@ func (a *Generate) Run(d *Data) (err error) {
 	assetDir := path.Join(
 		AssetDir,
 		a.application.Assets.Path)
+	err = nas.MkDir(assetDir, 0755)
+	if err != nil {
+		return
+	}
 	err = a.purge(assetDir)
 	if err != nil {
 		return


### PR DESCRIPTION
Support asset repository without path (using /).  To do this, the .git directory needs to be ignored when walking all repositories.  This is done by ignoring all .files.
Also, ensure the directory at `path` exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically creates the asset directory before processing, reducing setup friction and preventing run-time failures when the directory is missing.
- Bug Fixes
  - Skips hidden directories (names starting with “.”) during purge and template writing to avoid unintended traversal and processing.
  - Improves stability by halting on directory-creation errors early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->