### PR TITLE
:sparkles: Tag application with platform=Cloud Foundry

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -122,6 +122,7 @@ type Provider interface {
 	Use(identity *api.Identity)
 	Fetch(application *api.Application) (m *api.Manifest, err error)
 	Find(filter api.Map) (found []api.Application, err error)
+	Tag() string
 }
 
 // Engine is a template rendering engine.

--- a/cmd/cloudfoundry/provider.go
+++ b/cmd/cloudfoundry/provider.go
@@ -99,6 +99,11 @@ func (p *Provider) Find(filter api.Map) (found []api.Application, err error) {
 	return
 }
 
+// Tag returns the platform= tag name.
+func (p *Provider) Tag() string {
+	return "Cloud Foundry"
+}
+
 // client returns a cloudfoundry client.
 func (p *Provider) client(spaces ...string) (client *cfp.CloudFoundryProvider, err error) {
 	options := []cf.Option{

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -5,7 +5,6 @@ import "github.com/konveyor/tackle2-hub/api"
 const (
 	TagSource   = "platform-discovery"
 	TagCategory = "Platform"
-	Tag         = "Cloud Foundry"
 )
 
 // Fetch application manifest action.
@@ -31,7 +30,7 @@ func (a *Fetch) Run(d *Data) (err error) {
 	if err != nil {
 		return
 	}
-	err = a.setTag()
+	err = a.setTag(provider)
 	if err != nil {
 		return
 	}
@@ -56,7 +55,7 @@ func (a *Fetch) fetch(p Provider, app *api.Application) (err error) {
 }
 
 // setTag replaces the platform tag.
-func (a *Fetch) setTag() (err error) {
+func (a *Fetch) setTag(p Provider) (err error) {
 	cat := &api.TagCategory{Name: TagCategory}
 	err = addon.TagCategory.Ensure(cat)
 	if err != nil {
@@ -64,7 +63,7 @@ func (a *Fetch) setTag() (err error) {
 	}
 	tag := &api.Tag{
 		Category: api.Ref{ID: cat.ID},
-		Name:     Tag,
+		Name:     p.Tag(),
 	}
 	err = addon.Tag.Ensure(tag)
 	if err != nil {
@@ -74,7 +73,8 @@ func (a *Fetch) setTag() (err error) {
 	appTags.Source(TagSource)
 	err = appTags.Replace([]uint{tag.ID})
 	if err != nil {
-		addon.Activity("Application tagged.")
+		return
 	}
+	addon.Activity("Application tagged.")
 	return
 }


### PR DESCRIPTION
closes #23 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Applications are automatically tagged with a standardized platform tag during the fetch process.
  * Platform providers now supply a platform name used for tagging, ensuring consistent tag categorization across applications.
  * Tagging is applied early in the fetch flow and surfaced in activity/log messages on replacement errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->