### PR TITLE
:bug: generate when application has no manifest.

### DIFF
--- a/cmd/error.go
+++ b/cmd/error.go
@@ -10,20 +10,6 @@ var (
 	wrap = liberr.Wrap
 )
 
-type ManifestNotFound struct {
-}
-
-func (m *ManifestNotFound) Error() (s string) {
-	s = "No manifest associated with the application or found in the source repository."
-	return
-}
-
-func (e *ManifestNotFound) Is(err error) (matched bool) {
-	var inst *ManifestNotFound
-	matched = errors.As(err, &inst)
-	return
-}
-
 type RepositoryNotDefined struct {
 	Role string
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -586,9 +586,10 @@ func (a *Generate) manifest() (redacted, manifest *api.Manifest, err error) {
 }
 
 // userManifest returns the manifest contained in the repository.
+// An empty manifest is returned when not found.
 func (a *Generate) userManifest() (manifest *api.Manifest, err error) {
+	manifest = &api.Manifest{}
 	if a.application.Repository == nil {
-		err = &ManifestNotFound{}
 		return
 	}
 	sourceDir, err := a.cloneCode()
@@ -599,7 +600,7 @@ func (a *Generate) userManifest() (manifest *api.Manifest, err error) {
 	f, err := os.Open(file)
 	if err != nil {
 		if os.IsNotExist(err) {
-			err = &ManifestNotFound{}
+			err = nil
 		} else {
 			err = wrap(err)
 		}
@@ -608,7 +609,6 @@ func (a *Generate) userManifest() (manifest *api.Manifest, err error) {
 	defer func() {
 		_ = f.Close()
 	}()
-	manifest = &api.Manifest{}
 	decoder := yaml.NewDecoder(f)
 	err = decoder.Decode(&manifest.Content)
 	if err == nil {


### PR DESCRIPTION
closes: #39 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness for missing manifest files. The application now gracefully handles scenarios where the manifest file is unavailable or the repository is not configured by returning an empty manifest instead of raising an error. This improvement allows operations to continue smoothly with appropriate fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->